### PR TITLE
Python 2.6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ notifications:
 env:
   matrix:
     - TOXENV=flake8-py3
+    - TOXENV=py26
     - TOXENV=py27
     - TOXENV=py33
     - TOXENV=py34

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,8 @@ from setuptools import setup
 
 from setuptools.command.test import test as TestCommand  # noqa: N812
 
+PY26 = sys.version_info[0:2] < (2, 7)
+
 
 class PyTest(TestCommand):
     """Test harness."""
@@ -43,8 +45,8 @@ dependencies = [
     'github3.py>=1.0.0a1',
     'parse',
     'python-dateutil',
-    'ConfigArgParse',
 ]
+dependencies.append('ConfigArgParse>=0.10.0' if PY26 else 'ConfigArgParse')
 
 dependency_links = [
     'git+https://github.com/jayvdb/travispy@fetch-log#egg=travispy-0.3.3'
@@ -96,6 +98,7 @@ setup(
         'Operating System :: POSIX :: Linux',
         'Operating System :: Unix',
         'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 3',
         'Topic :: Software Development :: Libraries',
         'Topic :: Software Development :: Quality Assurance',

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 minversion = 1.6
 skipsdist = True
-envlist = flake8-py3,py27,py33,py34
+envlist = flake8-py3,py26,py27,py33,py34
 
 [testenv]
 commands =


### PR DESCRIPTION
Python 2.6 support was added to ConfigArgParse in version 0.10.0

Closes #1 
